### PR TITLE
I fixed the tests and made some minor updates

### DIFF
--- a/apiclient.py
+++ b/apiclient.py
@@ -170,6 +170,7 @@ class ApiClient(object):
         self._token = bool(self._token) and self._token or self.getToken(self._userid)
         self._key = bool(self._key) and self._key or self.generateKey(self._token, self.application_token, passwd)
 
+    @property
     def isAuthenticated(self):
         '''Returns whether the session has been authenticated.'''
         return bool(self._key)

--- a/test_poodledo.py
+++ b/test_poodledo.py
@@ -42,7 +42,7 @@ class PoodleDoTest(unittest.TestCase):
             self.app_token = config.get('application', 'token')
             if not cached_client:
                 cached_client = ApiClient(app_id=self.app_id,app_token=self.app_token)
-        return super(MyTest, self).__init__(methodName)
+        return super(PoodleDoTest, self).__init__(methodName)
 
 
     def setUp(self):
@@ -103,7 +103,7 @@ class PoodleDoTest(unittest.TestCase):
         #test parse
         datetime.fromtimestamp(int(info.lastedit_task))-timedelta(hours = .5*int(info.timezone))
         if self.mocked:
-            self.assertEquals(info.lastedit_task, 1228476730)
+            self.assertEquals(info.lastedit_task, '1228476730')
         else:
             assert info.lastedit_task.isdigit()
 

--- a/test_poodledo.py
+++ b/test_poodledo.py
@@ -2,11 +2,8 @@
 # -*- coding: UTF-8 -*-
 
 import sys
-import os
 
 import unittest
-import urllib2
-import time
 from datetime import datetime,timedelta
 
 from poodledo.apiclient import ApiClient, ToodledoError
@@ -26,9 +23,6 @@ class MockOpener(object):
             return open(self.url_map[url],'r')
         else:
             raise AssertionError("Unexpected url requested:  "+url)
-            # print url
-            return open(self.url_map['default'],'r')
-
 
 class PoodleDoTest(unittest.TestCase):
     def __init__(self, methodName='runTest'):
@@ -42,7 +36,7 @@ class PoodleDoTest(unittest.TestCase):
             self.app_token = config.get('application', 'token')
             if not cached_client:
                 cached_client = ApiClient(app_id=self.app_id,app_token=self.app_token)
-        return super(PoodleDoTest, self).__init__(methodName)
+        super(PoodleDoTest, self).__init__(methodName)
 
 
     def setUp(self):
@@ -94,6 +88,7 @@ class PoodleDoTest(unittest.TestCase):
     def test_authenticate(self):
         api = self._createApiClient()
 
+        self.assertFalse( api.isAuthenticated)
         api.authenticate(self.user_email, self.password)
         self.assertTrue( api.isAuthenticated )
 
@@ -109,7 +104,7 @@ class PoodleDoTest(unittest.TestCase):
 
 def suite():
     loader = unittest.TestLoader()
-    testsuite = loader.loadTestsFromTestCase(MyTest)
+    testsuite = loader.loadTestsFromTestCase(PoodleDoTest)
     return testsuite
 
 

--- a/test_poodledo.py
+++ b/test_poodledo.py
@@ -9,7 +9,9 @@ import urllib2
 import time
 from datetime import datetime,timedelta
 
-from poodledo import ApiClient, ToodledoError
+from poodledo.apiclient import ApiClient, ToodledoError
+from poodledo.cli import get_config
+
 
 class MockOpener(object):
     def __init__(self):
@@ -22,38 +24,63 @@ class MockOpener(object):
         if url in self.url_map:
             return open(self.url_map[url],'r')
         else:
+            raise AssertionError("Unexpected url requested:  "+url)
             # print url
             return open(self.url_map['default'],'r')
 
 class MyTest(unittest.TestCase):
 
+
+    def __init__(self, methodName='runTest'):
+        self.mocked = True
+        if not self.mocked:
+            config = get_config()
+            self.user_email = config.get('config', 'username')
+            self.password = config.get('config', 'password')
+            self.app_id = config.get('application', 'id')
+            self.app_token = config.get('application', 'token')
+        return super(MyTest, self).__init__(methodName)
+
+
     def setUp(self):
-        self.opener = MockOpener()
-        self.opener.add_file('default', 'testdata/error.xml')
-        self.opener.add_file(
-                'http://www.toodledo.com/api.php?email=test%40test.de;method=getUserid;pass=mypassword',
-                'testdata/getUserid_good.xml')
-        self.opener.add_file(
-                'http://www.toodledo.com/api.php?method=getToken;userid=sampleuserid156',
-                'testdata/getToken_good.xml')
-        self.opener.add_file(
-                'http://www.toodledo.com/api.php?key=83210ee13e69133d9b241e2f24cf5850;method=getServerInfo',
-                'testdata/getServerInfo.xml')
+        if self.mocked:
+            self.opener = MockOpener()
+            self.opener.add_file('default', 'testdata/error.xml')
+            self.opener.add_file(
+                #   'https://api.toodledo.com/2/account/lookup.php?appid=PoodledoAppTest&email=test%40test.de&f=xml&pass=mypassword&sig=40f30694b091f2c98e8c192885604beb'
+                    'https://api.toodledo.com/2/account/lookup.php?appid=PoodledoAppTest&email=test%40test.de&f=xml&pass=mypassword&sig=40f30694b091f2c98e8c192885604beb',
+                    'testdata/getUserid_good.xml')
+            self.opener.add_file(
+                'https://api.toodledo.com/2/account/lookup.php?appid=PoodledoAppTest&email=test%40test.de&f=xml&pass=mypasswordwrong_password&sig=40f30694b091f2c98e8c192885604beb',
+                'testdata/getUserid_bad.xml')
+            self.opener.add_file(
+                    'https://api.toodledo.com/2/account/token.php?appid=PoodledoAppTest&f=xml&sig=0bf850945b57d0a50c3eeabb2ec5fac3&userid=sampleuserid156',
+                    'testdata/getToken_good.xml')
+            self.opener.add_file(
+                    'http://api.toodledo.com/2/account/get.php?f=xml&key=6f931665ef2604b76b82ae814aa9a686',
+                    'testdata/getServerInfo.xml')
+            self.user_email = 'test@test.de'
+            self.password = 'mypassword'
+            self.app_id = 'PoodledoAppTest'
+            self.app_token = 'nonsensetoken'
+
 
     def _createApiClient(self,authenticate=False):
-        api = ApiClient()
-        api.set_urlopener(self.opener)
+        api = ApiClient(app_id=self.app_id,app_token=self.app_token)
+        if self.mocked:
+            api._urlopener = self.opener
         if authenticate:
-            api.authenticate('test@test.de', 'mypassword')
+            api.authenticate(self.user_email, self.password)
         return api
 
     def test_getUserid(self):
         api = self._createApiClient()
 
-        api.getUserid('test@test.de','mypassword')
-        self.assertRaises(ToodledoError, api.getUserid, 'test@test.de','wrong_password')
+        api.getUserid(self.user_email,self.password)
+        self.assertRaises(ToodledoError, api.getUserid, self.user_email,self.password + 'wrong_password')
 
     def test_getToken(self):
+        assert self.mocked, "This test only runs in mocked configuration"
         api = self._createApiClient()
 
         token = api.getToken('sampleuserid156')
@@ -62,12 +89,12 @@ class MyTest(unittest.TestCase):
     def test_authenticate(self):
         api = self._createApiClient()
 
-        api.authenticate('test@test.de', 'mypassword')
+        api.authenticate(self.user_email, self.password)
         self.assertTrue( api.isAuthenticated )
 
-    def test_getServerInfo(self):
+    def test_getAccountInfo(self):
         api = self._createApiClient(True)
-        info = api.getServerInfo()
+        info = api.getAccountInfo()
         self.assertEquals(info.unixtime, 1228476730)
         # self.assertEquals(info.date, 'Fri, 05 Dec 2008 05:32:10 -0600')
         if time.daylight:

--- a/testdata/getServerInfo.xml
+++ b/testdata/getServerInfo.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>	<server>
-	<lastedit_task>1228476730</unixtime>
-	<tokenexpires>238.53</tokenexpires>
-	</server>
+<?xml version="1.0" encoding="UTF-8"?>	<account>
+    <timezone>-6</timezone>
+	<lastedit_task>1228476730</lastedit_task>
+	</account>
 	

--- a/testdata/getServerInfo.xml
+++ b/testdata/getServerInfo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>	<server>
-	<unixtime>1228476730</unixtime>
-	<date>Fri, 05 Dec 2008 05:32:10 -0600</date>
+	<lastedit_task>1228476730</unixtime>
 	<tokenexpires>238.53</tokenexpires>
 	</server>
 	

--- a/testdata/getUserid_bad.xml
+++ b/testdata/getUserid_bad.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><error>Bad Password</error>


### PR DESCRIPTION
Tests now can run against the real toodledo service using your existing config file. 

I had to change getServerInfo test to getAccountInfo since the server info is no longer available, I did not rename the xml file yet in case you want to merge this some other way or know of a new server info api.
