### PR TITLE
avoid double-decoding unicode when python behaves like python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+build/
+dist/
+*.egg-info/

--- a/poodledo/toodledodata.py
+++ b/poodledo/toodledodata.py
@@ -19,6 +19,12 @@ def _date(string):
 def _boolstr(string):
     return bool(int(string))
 
+def _unicode(string):
+    # https://github.com/django-extensions/django-extensions/commit/5d330294117b0e7bb2b82f44d23ce9ef6d339724
+    if not six.PY3 and not isinstance(string, six.text_type):
+        string = six.u(string)
+    return string
+
 def flatten(x):
     result = []
     if not hasattr(x, "__iter__"):
@@ -107,7 +113,7 @@ class ToodledoData(object):
                 'location': int,
                 'meta': str,
                 'modified': int,
-                'note': six.u,
+                'note': _unicode,
                 'order': str,
                 'parent': int,
                 'priority': int,
@@ -124,15 +130,15 @@ class ToodledoData(object):
                 'tag': str,
                 'timer': int,
                 'timeron': str,
-                'title': six.u,
+                'title': _unicode,
                 },
             'notebook': {
                 'id': int,
                 'folder': int,
                 'added': str,
                 'modified': str,
-                'title': six.u,
-                'text': six.u,
+                'title': _unicode,
+                'text': _unicode,
                 'private': _boolstr,
                 'stamp': str,
                 },

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os, shutil
 
-version = '0.2'
+version = '0.2.1'
 
 setup(name='poodledo',
       version=version,


### PR DESCRIPTION
I started getting the following error:

```
File "/Users/idm/.virtualenvs/greenthink/lib/python2.7/site-packages/poodledo-0.2-py2.7.egg/poodledo/toodledodata.py", line 144, in __init__
    self.__dict__[elem.tag] = typemap[elem.tag](elem.text)
File "build/bdist.macosx-10.9-intel/egg/six.py", line 468, in u
    return unicode(s, "unicode_escape")
TypeError: decoding Unicode is not supported
```

I think this began when I updated to OS X Mavericks, possibly related to the jump to Python 2.7.  I don't know.  At any rate, I think I fixed the issue by adapting a bugfix from django:

https://github.com/django-extensions/django-extensions/commit/5d330294117b0e7bb2b82f44d23ce9ef6d339724

I'm sending along a pull request with the code that worked for me.  I did not test this on python 2.6 or 3.x, but I am banking on the django patch being correct for those versions.

I was hoping you could incorporate this and propagate to pypi, assuming the patch works for you too.
